### PR TITLE
[FIX] Paie: bulletins NA -> SOLDE DE TOUT COMPTE + fix regression ticket ND

### DIFF
--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1",
+    "version": "1.1.1",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -16,6 +16,20 @@ class HrPayslip(models.Model):
             if payslip.contract_id and payslip.contract_id.contract_category == 'not_declared':
                 payslip.is_undeclared_payslip = True
 
+    is_nd_ticket_payslip = fields.Boolean(
+        'Prints the N.D. 80mm ticket ?', compute="_compute_is_nd_ticket_payslip", store=False)
+
+    @api.depends('contract_id', 'struct_id')
+    def _compute_is_nd_ticket_payslip(self):
+        # Only undeclared payslips whose structure is NOT routed to report_final_settlement
+        # (i.e. struct name does not contain 'Solde Tout Compte') keep the dedicated 80mm
+        # "PAIEMENT" ticket (report_nd_payslip). This mirrors the exact substring used by
+        # _get_pdf_reports, so the "Solde Tout Compte - NA" structure (which DOES contain it)
+        # is excluded and follows the standard flow like declared payslips.
+        for payslip in self:
+            undeclared = bool(payslip.contract_id and payslip.contract_id.contract_category == 'not_declared')
+            payslip.is_nd_ticket_payslip = undeclared and 'Solde Tout Compte' not in (payslip.struct_id.name or '')
+
     overtime_hours_count = fields.Float(compute='_compute_overtime_hours')
 
     employee_id = fields.Many2one(

--- a/tanatech_hr_payroll/report/final_settlement.xml
+++ b/tanatech_hr_payroll/report/final_settlement.xml
@@ -71,8 +71,10 @@
 
             <!-- ===== Salary / Deductions tables block ===== -->
             <!-- Pull the line recordsets once, both columns share the same data source -->
-            <t t-set="salary_lines" t-value="o.line_ids.filtered(lambda l: l.category_id.code in ['BASIC', 'INDEM'])"/>
-            <t t-set="deduction_lines" t-value="o.line_ids.filtered(lambda l: l.category_id.code in ['DED', 'IRSA02', 'AJUST'])"/>
+            <!-- Gains: n'affiche que les lignes non nulles; GROSS/NET (totaux) exclus car hors liste -->
+            <t t-set="salary_lines" t-value="o.line_ids.filtered(lambda l: l.category_id.code in ['BASIC', 'INDEM', 'HSUPP', 'HSUPPEXO30', 'ALW'] and l.total != 0)"/>
+            <!-- Retenues: DED/IRSA02 conservés pour les bulletins déclarés; AJUST/ABS pour les N.D. -->
+            <t t-set="deduction_lines" t-value="o.line_ids.filtered(lambda l: l.category_id.code in ['DED', 'IRSA02', 'AJUST', 'ABS'] and l.total != 0)"/>
 
             <!-- Dynamic spacer: pad the shorter column with empty rows so both
                  tables end up with the same height, no matter how many lines
@@ -83,6 +85,12 @@
             <t t-set="total_salary_qty" t-value="sum(salary_lines.mapped('quantity'))"/>
             <t t-set="total_salary_amount" t-value="sum(salary_lines.mapped('total'))"/>
             <t t-set="total_deduction_amount" t-value="sum(deduction_lines.mapped('total'))"/>
+
+            <!-- Net à payer: la ligne de code règle SALNETAP fait foi; à défaut, somme
+                 ALGÉBRIQUE des gains et retenues (les retenues sont déjà négatives en base,
+                 donc addition, surtout pas gains - déductions). -->
+            <t t-set="salnetap_lines" t-value="o.line_ids.filtered(lambda l: l.salary_rule_id.code == 'SALNETAP')"/>
+            <t t-set="net_to_pay" t-value="sum(salnetap_lines.mapped('total')) if salnetap_lines else (total_salary_amount + total_deduction_amount)"/>
 
             <table style="width:100%; border-collapse:collapse; margin-bottom:15px;">
               <tr>
@@ -206,15 +214,6 @@
                 </td>
                 <td class="text-end" style="border:1px solid #2952a3; background-color:#e0e0e0; padding:6px;">
                   <strong>
-
-                    <t t-if="total_deduction_amount &lt; 0">
-                      <t t-set="net_to_pay" t-value="total_salary_amount + total_deduction_amount"/>
-                    </t>
-
-                    <t t-else="">
-                      <t t-set="net_to_pay" t-value="total_salary_amount - total_deduction_amount"/>
-                    </t>
-
                     <span t-esc="net_to_pay" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                   </strong>
                 </td>

--- a/tanatech_hr_payroll/views/hr_payslip_view.xml
+++ b/tanatech_hr_payroll/views/hr_payslip_view.xml
@@ -8,18 +8,19 @@
     <field name="arch" type="xml">
       <xpath expr="//form/header" position="before">
         <field name="is_undeclared_payslip" invisible="1"/>
+        <field name="is_nd_ticket_payslip" invisible="1"/>
       </xpath>
       <xpath expr="//button[@name='action_print_payslip']" position="attributes">
-                <!-- Route undeclared (N.D.) payslips through the standard print flow so
-                     _get_pdf_reports redirects them to report_final_settlement
-                     ("SOLDE DE TOUT COMPTE"), exactly like declared payslips. -->
-                <attribute name="invisible">not line_ids</attribute>
+                <!-- Standard print flow -> _get_pdf_reports -> report_final_settlement.
+                     Visible for declared AND for "Solde Tout Compte - NA"; hidden only for
+                     N.D. ticket payslips (which use the 80mm "PAIEMENT" ticket below). -->
+                <attribute name="invisible">not line_ids or is_nd_ticket_payslip</attribute>
             </xpath>
       <xpath expr="//button[@name='action_print_payslip']" position="after">
-                <!-- N.D. ticket print disabled: kept hidden so undeclared payslips use the
-                     standard flow -> report_final_settlement. Method/template left as dead code. -->
+                <!-- 80mm "PAIEMENT" ticket: visible ONLY for N.D. payslips
+                     (undeclared and not routed to report_final_settlement). -->
                 <button string="Print" name="action_print_nd_payslip" type="object"
-                        invisible="1"/>
+                        invisible="not line_ids or not is_nd_ticket_payslip"/>
             </xpath>
       <xpath expr="//field[@name='number_of_hours']" position="attributes">
         <attribute name="widget"></attribute>

--- a/tanatech_hr_payroll/views/hr_payslip_view.xml
+++ b/tanatech_hr_payroll/views/hr_payslip_view.xml
@@ -10,14 +10,16 @@
         <field name="is_undeclared_payslip" invisible="1"/>
       </xpath>
       <xpath expr="//button[@name='action_print_payslip']" position="attributes">
-                <!-- Hide the standard "Pay slip" (BULLETIN DE PAIE) print on undeclared
-                     payslips: it reads contract_id.wage (0 for N.D.) and prints all zeros.
-                     N.D. payslips must be printed with the dedicated ticket below. -->
-                <attribute name="invisible">not line_ids or is_undeclared_payslip</attribute>
+                <!-- Route undeclared (N.D.) payslips through the standard print flow so
+                     _get_pdf_reports redirects them to report_final_settlement
+                     ("SOLDE DE TOUT COMPTE"), exactly like declared payslips. -->
+                <attribute name="invisible">not line_ids</attribute>
             </xpath>
       <xpath expr="//button[@name='action_print_payslip']" position="after">
+                <!-- N.D. ticket print disabled: kept hidden so undeclared payslips use the
+                     standard flow -> report_final_settlement. Method/template left as dead code. -->
                 <button string="Print" name="action_print_nd_payslip" type="object"
-                        invisible="not line_ids or not is_undeclared_payslip"/>
+                        invisible="1"/>
             </xpath>
       <xpath expr="//field[@name='number_of_hours']" position="attributes">
         <attribute name="widget"></attribute>


### PR DESCRIPTION
## Objectif
Aligner l'impression des bulletins de la structure **« Solde Tout Compte - NA »** sur le PDF **« SOLDE DE TOUT COMPTE »** (`report_final_settlement`), identique aux bulletins déclarés « Solde Tout Compte » — tout en préservant le ticket de caisse **« PAIEMENT » (80 mm)** de la structure **« ND »**.

Hotfix ciblé : **uniquement** les 2 commits paie, cherry-pickés depuis `stage_2` sur une branche partant de `production` (stage_2 est 428 commits devant production, hors périmètre).

## Contenu (2 commits)
1. **Routage NA → report_final_settlement** (`85ba5e8` sur stage_2)
   - Bouton standard rendu au flux `_get_pdf_reports` → `report_final_settlement` pour les NA.
   - Template `final_settlement.xml` : catégories gains élargies `['BASIC','INDEM','HSUPP','HSUPPEXO30','ALW']`, retenues `['DED','IRSA02','AJUST','ABS']` (DED/IRSA02 conservés pour les déclarés), lignes à 0 masquées, **Net à Payer = ligne SALNETAP** sinon somme algébrique (retenues déjà négatives).
2. **Fix régression ticket ND** (`c3e7020` sur stage_2)
   - Nouveau booléen calculé `is_nd_ticket_payslip = (contrat not_declared) ET ('Solde Tout Compte' NOT in struct_id.name)`, réutilisant la même sous-chaîne que `_get_pdf_reports`.
   - Pilotage des boutons basé dessus : **ND garde son ticket 80 mm**, NA et déclaré prennent le bouton standard.

## Comportement final
| Structure | Bouton visible | PDF |
|---|---|---|
| Déclaré | Standard | flux standard |
| Solde Tout Compte - NA | Standard | report_final_settlement (« SOLDE DE TOUT COMPTE ») |
| ND | Ticket | report_nd_payslip (« PAIEMENT », 80 mm) |

## Fichiers modifiés (4)
- `tanatech_hr_payroll/models/hr_payslip.py` — champ calculé `is_nd_ticket_payslip`
- `tanatech_hr_payroll/views/hr_payslip_view.xml` — visibilité des boutons d'impression
- `tanatech_hr_payroll/report/final_settlement.xml` — filtres catégories + net SALNETAP
- `tanatech_hr_payroll/__manifest__.py` — bump version **1.1 → 1.1.2**

Non touchés : hook `_get_pdf_reports`, template `report_nd_payslip` (laissé en place).

Validé visuellement sur stage_2 (4 cas OK). **Ne pas merger automatiquement** — merge manuel sur Odoo.sh par Karim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)