### PR TITLE
Correctif décompte des congés : exclusion des dimanches et jours fériés

### DIFF
--- a/tanatech_hr_holidays/__manifest__.py
+++ b/tanatech_hr_holidays/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Holidays",
-    "version": "1.0",
+    "version": "1.1",
     "summary": "Manage your Holidays activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_holidays/data/hr_leave_type_data.xml
+++ b/tanatech_hr_holidays/data/hr_leave_type_data.xml
@@ -2,8 +2,14 @@
 <odoo>
     <data noupdate="0">
 
+        <!--
+            Neutralisation du décompte custom "week-end inclus" sur le type "Congés payés".
+            La valeur est forcée à False (noupdate="0") pour être appliquée à l'upgrade,
+            afin de revenir au décompte standard Odoo (jours ouvrables selon l'horaire,
+            hors dimanches et jours fériés légaux).
+        -->
         <record id="hr_holidays.holiday_status_cl" model="hr.leave.type">
-            <field name="is_deducted_if_weekend_included">True</field>
+            <field name="is_deducted_if_weekend_included">False</field>
         </record>
 
     </data>

--- a/tanatech_hr_holidays/models/hr_leave.py
+++ b/tanatech_hr_holidays/models/hr_leave.py
@@ -1,66 +1,6 @@
 # -*- coding:utf-8 -*-
 from odoo import api, Command, models, fields
 
-from datetime import datetime, time, date, timedelta
-from pytz import timezone, utc
-import logging
-
 
 class HrLeave(models.Model):
     _inherit = 'hr.leave'
-
-    leave_friday_end_increases_duration = fields.Boolean('Friday end date increased duration', default=False, compute="_compute_duration")
-    leave_weekend_included_increases_duration = fields.Boolean('Friday end date increased duration', default=False, compute="_compute_duration")
-
-    @api.depends('date_from', 'date_to', 'resource_calendar_id', 'holiday_status_id.request_unit')
-    def _compute_duration(self):
-        durations = self._get_durations()
-        for leave in self:
-            days, hours = durations[leave.id]
-            leave.number_of_hours = hours
-            leave.number_of_days = days
-
-            leave_friday_end = False
-            leave_weekend_included = False
-            if leave.holiday_status_id.is_deducted_if_weekend_included:
-                fridays = self._get_fridays(leave.date_from.date(), leave.date_to.date())
-                
-                if leave.date_to.date() in fridays:
-                    leave.number_of_days = days + 3
-                    added_hours = (hours / days) * 3
-                    leave.number_of_hours = hours + added_hours
-                    leave_friday_end = True
-                    
-                weekends_number = self._count_weekends(leave.date_from.date(), leave.date_to.date())
-                if weekends_number > 0:
-                    leave.number_of_days = leave.number_of_days + (weekends_number)
-                    added_hours = (hours / days) * (weekends_number)
-                    leave.number_of_hours = leave.number_of_hours + added_hours
-                    leave_weekend_included = True
-                    
-            leave.leave_friday_end_increases_duration = leave_friday_end
-            leave.leave_weekend_included_increases_duration = leave_weekend_included
-
-    def _get_fridays(self, start_date, end_date):
-        """
-        Return a list of all Fridays between start_date and end_date (inclusive).
-        """
-        fridays = []
-        current = start_date
-        while current <= end_date:
-            if current.weekday() == 4:  # 4 = Friday
-                fridays.append(current)
-            current += timedelta(days=1)
-        return fridays
-
-    def _count_weekends(self, start_date, end_date):
-        """
-        Count Saturdays and Sundays between start_date and end_date (inclusive).
-        """
-        count = 0
-        current = start_date
-        while current <= end_date:
-            if current.weekday() in (5, 6):  # 5 = Saturday, 6 = Sunday
-                count += 1
-            current += timedelta(days=1)
-        return count

--- a/tanatech_hr_holidays/views/hr_leave_views.xml
+++ b/tanatech_hr_holidays/views/hr_leave_views.xml
@@ -1,24 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
-    <record id="hr_leave_view_form_inherit" model="ir.ui.view">
-        <field name="name">hr.leave.view.form.inherit</field>
-        <field name="model">hr.leave</field>
-        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//div[@name='duration_warning']" position="before">
-                <field name="leave_friday_end_increases_duration" invisible="1"/>
-                <field name="leave_weekend_included_increases_duration" invisible="1"/>
-                <div name="friday_warning" class="alert alert-warning my-2" invisible="not leave_friday_end_increases_duration and not leave_weekend_included_increases_duration" role="alert">
-                    <p invisible="not leave_friday_end_increases_duration">
-                        <span>Leave ending on Friday gets its duration increased by 3 days.</span>
-                    </p>
-                    <p invisible="not leave_weekend_included_increases_duration">
-                        <span>Leave including weekend (saturday and Sunday) gets its duration increased by 2 days.</span>
-                    </p>
-                </div>
-            </xpath>
-        </field>
-    </record>
-
+    <!--
+        La vue héritée qui affichait les avertissements "durée augmentée de 3 jours (fin vendredi)"
+        et "week-end inclus" a été retirée : ce comportement custom a été supprimé, le décompte
+        revient au calcul standard Odoo (jours ouvrables selon l'horaire, hors dimanches et fériés).
+    -->
 </odoo>


### PR DESCRIPTION
## Contexte

Les demandes de congé décomptaient à tort les **dimanches** et les **jours fériés légaux**, alors que l'horaire de travail (lun-ven + samedi matin) ne les inclut pas et que le champ standard « Jours fériés inclus » est décoché. Exemples constatés : congé du 13/08 au 26/08 = 14,5 j au lieu de 10,5 ; samedi matin = 1,5 j ; etc.

## Correctif

- **Suppression de la surcharge `_compute_duration`** du module `tanatech_hr_holidays` : retrait de l'inflation custom qui rajoutait les week-ends (samedis **et** dimanches recomptés) et les **+3 jours** lorsque le congé se terminait un vendredi. Retour au calcul **standard Odoo** via `_get_durations()` — décompte en jours ouvrables selon l'horaire de travail, sans jamais décompter les dimanches ni les jours fériés légaux.
- **Neutralisation du flag `is_deducted_if_weekend_included`** sur le type **Congés payés** (`holiday_status_cl`), passé à `False` avec `noupdate="0"` pour application à l'upgrade. Le champ et ses vues sont conservés (neutralisation, pas suppression).
- **Bump de version `1.0` → `1.1`** du module `tanatech_hr_holidays` pour forcer l'upgrade incrémental au déploiement.

## Recette (validée sur `stage_2`)

- Demande de test **13/08 → 26/08 = 10,5 jours** (au lieu de 14,5) ✔
- Recalcul de l'historique **OK sur 3 congés** ✔

## Notes

- Ne pas merger sans validation finale.
- Après upgrade, l'historique déjà validé conserve sa durée en base sauf recalcul explicite (traité en recette sur les congés concernés).
