### PR TITLE
[DEPLOY] Impression paie NA + renommage ND→NA (payroll 1.1.7, contract 1.4)

### DIFF
--- a/tanatech_hr_contract/__manifest__.py
+++ b/tanatech_hr_contract/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Contracts",
-    "version": "1.3",
+    "version": "1.4",
     "summary": "Manage your Contracts activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_contract/i18n/fr.po
+++ b/tanatech_hr_contract/i18n/fr.po
@@ -4,16 +4,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0+e-20240905\n"
+"Project-Id-Version: Odoo Server 18.0+e-20251201\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-02 08:39+0000\n"
-"PO-Revision-Date: 2025-07-02 08:39+0000\n"
+"POT-Creation-Date: 2026-01-05 06:45+0000\n"
+"PO-Revision-Date: 2026-01-05 09:46+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.8\n"
 
 #. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_contract__family_allowance
@@ -88,7 +90,7 @@ msgid ""
 "Tips : Remove the declared contract."
 msgstr ""
 "Un contrat non affecté ne peut pas être supprimé explicitement! \n"
-"Conseils : Supprimez le contrat affecté."
+"Conseils : Supprimez le contrat déclaré."
 
 #. module: tanatech_hr_contract
 #. odoo-python
@@ -98,7 +100,7 @@ msgid ""
 "Tips : Archive the declared contract."
 msgstr ""
 "Un contrat non affecté ne peut pas être archivé explicitement! \n"
-"Conseils : Archiver le contrat affecté."
+"Conseils : Archivez le contrat déclaré."
 
 #. module: tanatech_hr_contract
 #. odoo-python
@@ -108,7 +110,7 @@ msgid ""
 "Tips : Unarchive the declared contract."
 msgstr ""
 "Un contrat non affecté ne peut pas être désarchivé explicitement! \n"
-"Conseils : Désarchiver le contrat affecté."
+"Conseils : Désarchivez le contrat déclaré."
 
 #. module: tanatech_hr_contract
 #: model:ir.ui.menu,name:tanatech_hr_contract.hr_menu_declared_contracts
@@ -200,7 +202,7 @@ msgstr "Type de structure salariale"
 #. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__count
 msgid "# Undeclared Payslip"
-msgstr "# Fiche de paie non affecté"
+msgstr "# Fiches de paie non affectées"
 
 #. module: tanatech_hr_contract
 #: model:ir.model.fields.selection,name:tanatech_hr_contract.selection__hr_payroll_undeclared_report__work_entry_source__attendance
@@ -228,7 +230,19 @@ msgid "Basic Wage for Time Off"
 msgstr "Salaire de base pour les congés"
 
 #. module: tanatech_hr_contract
+#: model:ir.model.fields.selection,name:tanatech_hr_contract.selection__hr_contract__state__cancel
+msgid "Cancelled"
+msgstr "Annulé"
+
+#. module: tanatech_hr_contract
+#. odoo-python
+#: code:addons/tanatech_hr_contract/models/hr_contract.py:0
+msgid "Cannot modify undeclared contract status !"
+msgstr "Impossible de modifier le statut du contrat non affecté !"
+
+#. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__company_id
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_search
 msgid "Company"
 msgstr "Société"
 
@@ -248,9 +262,56 @@ msgid "Days of Unpaid Time Off"
 msgstr "Jours de congés non payés"
 
 #. module: tanatech_hr_contract
+#: model:ir.ui.menu,name:tanatech_hr_contract.menu_report_declared_payroll
+msgid "Declared Payroll"
+msgstr "Paie déclarée"
+
+#. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__display_name
 msgid "Display Name"
 msgstr "Nom d'affichage"
+
+#. module: tanatech_hr_contract
+#: model:ir.model,name:tanatech_hr_contract.model_hr_contract
+msgid "Employee Contract"
+msgstr "Contrat de l'employé"
+
+#. module: tanatech_hr_contract
+#: model:ir.model.fields,help:tanatech_hr_contract.field_hr_contract__resource_calendar_id
+msgid ""
+"Employee's working schedule.\n"
+"        When left empty, the employee is considered to have a fully flexible schedule, allowing them to work without any time limit, anytime of the week.\n"
+"        "
+msgstr ""
+"Emploi du temps de l'employé.\n"
+"        Si laissé vide, l'employé est considéré comme ayant un emploi du temps totalement flexible, lui permettant de travailler sans aucune limite de temps, n'importe quel jour de la semaine.\n"
+"        "
+
+#. module: tanatech_hr_contract
+#: model:ir.model.fields.selection,name:tanatech_hr_contract.selection__hr_contract__state__close
+msgid "Expired"
+msgstr "Expiré"
+
+#. module: tanatech_hr_contract
+#. odoo-python
+#: code:addons/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
+msgid "From %(from_date)s to %(end_date)s"
+msgstr ""
+
+#. module: tanatech_hr_contract
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.view_hr_payslip_filter_inherit
+msgid "From declared contract"
+msgstr "D'un contrat déclaré"
+
+#. module: tanatech_hr_contract
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.view_hr_payslip_filter_inherit
+msgid "From undeclared contract"
+msgstr "D'un contrat non affecté"
+
+#. module: tanatech_hr_contract
+#: model:ir.model,name:tanatech_hr_contract.model_hr_payslip_employees
+msgid "Generate payslips for all selected employees"
+msgstr "Génère les fiches de paie pour tous les employés sélectionnés"
 
 #. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__gross_wage
@@ -258,12 +319,29 @@ msgid "Gross Wage"
 msgstr "Salaire brut"
 
 #. module: tanatech_hr_contract
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.hr_contract_not_delcared_view_search
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_search
+msgid "Group By"
+msgstr ""
+
+#. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__id
 msgid "ID"
 msgstr "ID"
 
 #. module: tanatech_hr_contract
+#: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_contract__kanban_state
+msgid "Kanban State"
+msgstr "État kanban"
+
+#. module: tanatech_hr_contract
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_search
+msgid "Last 365 Days Payslip"
+msgstr "Fiche de paie des 365 derniers jours"
+
+#. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__master_department_id
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_search
 msgid "Master Department"
 msgstr "Département parent"
 
@@ -271,6 +349,17 @@ msgstr "Département parent"
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__net_wage
 msgid "Net Wage"
 msgstr "Salaire net"
+
+#. module: tanatech_hr_contract
+#: model:ir.model.fields.selection,name:tanatech_hr_contract.selection__hr_contract__state__draft
+msgid "New"
+msgstr "Nouveau"
+
+#. module: tanatech_hr_contract
+#. odoo-python
+#: code:addons/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
+msgid "New Payslip"
+msgstr ""
 
 #. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__number_of_days
@@ -283,23 +372,24 @@ msgid "Number of Hours"
 msgstr "Nombre d'heures"
 
 #. module: tanatech_hr_contract
+#: model:ir.actions.server,name:tanatech_hr_contract.ir_actions_server_action_open_undeclared_reporting
+msgid "Open Undeclared Payroll Reporting"
+msgstr "Ouvrir l'analyse de la paie non affectée"
+
+#. module: tanatech_hr_contract
 #: model:ir.model.fields.selection,name:tanatech_hr_contract.selection__hr_payroll_undeclared_report__work_type__2
 msgid "Paid Time Off"
 msgstr "Congés payés"
 
 #. module: tanatech_hr_contract
-#: model:ir.actions.act_window,name:tanatech_hr_contract.payroll_undeclared_report_action
-#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.hr_payroll_undeclared_report_view_tree
-#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_graph
-#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_pivot
-#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_search
-msgid "Undeclared Payroll Analysis"
-msgstr "Analyse de la paie non affectée"
+#: model:ir.model,name:tanatech_hr_contract.model_hr_payslip
+msgid "Pay Slip"
+msgstr "Fiche de paie"
 
 #. module: tanatech_hr_contract
-#: model:ir.model,name:tanatech_hr_contract.model_hr_payroll_undeclared_report
-msgid "Undeclared Payroll Analysis Report"
-msgstr "Rapport d'analyse de paie non affectée"
+#: model:ir.model,name:tanatech_hr_contract.model_hr_payroll_report
+msgid "Payroll Analysis Report"
+msgstr "Rapport d'analyse de paie"
 
 #. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__payslip_id
@@ -322,9 +412,101 @@ msgid "Regular Working Day"
 msgstr "Journée de travail régulière"
 
 #. module: tanatech_hr_contract
+#: model:res.groups,name:tanatech_hr_contract.group_restrict_field_wage
+msgid "Restrict field wage"
+msgstr "Restreindre le champ salaire"
+
+#. module: tanatech_hr_contract
+#: model:ir.model.fields.selection,name:tanatech_hr_contract.selection__hr_contract__state__open
+msgid "Running"
+msgstr "En cours"
+
+#. module: tanatech_hr_contract
+#: model:ir.model,name:tanatech_hr_contract.model_hr_salary_rule
+msgid "Salary Rule"
+msgstr "Règle salariale"
+
+#. module: tanatech_hr_contract
+#: model:ir.model,name:tanatech_hr_contract.model_hr_payroll_structure
+msgid "Salary Structure"
+msgstr "Structure salariale"
+
+#. module: tanatech_hr_contract
+#: model:ir.actions.server,name:tanatech_hr_contract.action_cancel_contracts
+msgid "Set to cancelled"
+msgstr "Définir comme annulé"
+
+#. module: tanatech_hr_contract
+#: model:ir.actions.server,name:tanatech_hr_contract.action_draft_contracts
+msgid "Set to draft"
+msgstr "Mettre en brouillon"
+
+#. module: tanatech_hr_contract
+#: model:ir.actions.server,name:tanatech_hr_contract.action_expire_contracts
+msgid "Set to expired"
+msgstr "Définir comme expiré"
+
+#. module: tanatech_hr_contract
+#: model:ir.actions.server,name:tanatech_hr_contract.action_run_contracts
+msgid "Set to running"
+msgstr "Mettre en cours"
+
+#. module: tanatech_hr_contract
+#. odoo-python
+#: code:addons/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
+msgid "Some work entries could not be validated."
+msgstr "Certaines prestations n'ont pas pu être validées."
+
+#. module: tanatech_hr_contract
+#: model:ir.model.fields,help:tanatech_hr_contract.field_hr_contract__state
+msgid "Status of the contract"
+msgstr "Statut du contrat"
+
+#. module: tanatech_hr_contract
+#: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payslip__structure_domain_ids
+msgid "Structure Domain"
+msgstr ""
+
+#. module: tanatech_hr_contract
+#: model_terms:ir.actions.act_window,help:tanatech_hr_contract.payroll_undeclared_report_action
+msgid "This report performs analysis on your undeclared payslip."
+msgstr "Ce rapport analyse vos fiches de paie non affectées."
+
+#. module: tanatech_hr_contract
+#. odoo-python
+#: code:addons/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
+msgid "Time intervals to look for:%s"
+msgstr "Intervalles de temps à vérifier : %s "
+
+#. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__type
 msgid "Type"
 msgstr "Type"
+
+#. module: tanatech_hr_contract
+#. odoo-javascript
+#: code:addons/tanatech_hr_contract/static/src/js/custom_statusbar.js:0
+msgid "Undeclared Contract Status"
+msgstr "Statut du contrat non affecté"
+
+#. module: tanatech_hr_contract
+#: model:ir.ui.menu,name:tanatech_hr_contract.menu_report_undeclared_payroll
+msgid "Undeclared Payroll"
+msgstr "Paie non affectée"
+
+#. module: tanatech_hr_contract
+#: model:ir.actions.act_window,name:tanatech_hr_contract.payroll_undeclared_report_action
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.hr_payroll_undeclared_report_view_tree
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_graph
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_pivot
+#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_search
+msgid "Undeclared Payroll Analysis"
+msgstr "Analyse de la paie non affectée"
+
+#. module: tanatech_hr_contract
+#: model:ir.model,name:tanatech_hr_contract.model_hr_payroll_undeclared_report
+msgid "Undeclared Payroll Analysis Report"
+msgstr "Rapport d'analyse de paie non affectée"
 
 #. module: tanatech_hr_contract
 #: model:ir.model.fields.selection,name:tanatech_hr_contract.selection__hr_payroll_undeclared_report__work_type__3
@@ -337,7 +519,7 @@ msgid "Work Days"
 msgstr "Jours de travail"
 
 #. module: tanatech_hr_contract
-#: model:ir.model.fields,field_description:hr_payroll.field_hr_payroll_undeclared_report__work_entry_source
+#: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_payroll_undeclared_report__work_entry_source
 msgid "Work Entry Source"
 msgstr "Source de la prestation"
 
@@ -357,75 +539,12 @@ msgid "Work, (un)paid Time Off"
 msgstr "Travail, congés (non) payés"
 
 #. module: tanatech_hr_contract
-#: model:ir.ui.menu,name:tanatech_hr_contract.menu_report_declared_payroll
-msgid "Declared Payroll"
-msgstr "Paie affectée"
-
-#. module: tanatech_hr_contract
-#: model:ir.ui.menu,name:tanatech_hr_contract.menu_report_undeclared_payroll
-msgid "Undeclared Payroll"
-msgstr "Paie non affectée"
-
-#. module: tanatech_hr_contract
 #. odoo-python
-#: code:tanatech/tanatech/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
-msgid "Some work entries could not be validated."
-msgstr "Certaines prestations n'ont pas pu être validées."
-
-#. module: tanatech_hr_contract
-#. odoo-python
-#: code:tanatech/tanatech/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
-msgid "Time intervals to look for:%s"
-msgstr "Intervalles de temps à vérifier : %s "
-
-#. module: tanatech_hr_contract
-#. odoo-python
-#: code:tanatech/tanatech/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
+#: code:addons/tanatech_hr_contract/wizard/hr_payroll_payslips_by_employees.py:0
 msgid "You must select employee(s) to generate payslip(s)."
 msgstr ""
 "Vous devez sélectionner un ou des employés pour générer une ou des fiches de"
 " paie."
-
-#. module: tanatech_hr_contract
-#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.payroll_undeclared_report_view_search
-msgid "Last 365 Days Payslip"
-msgstr "Fiche de paie des 365 derniers jours"
-
-#. module: tanatech_hr_contract
-#. odoo-python
-#: code:tanatech/tanatech/tanatech_hr_contract/models/hr_contract.py:0
-msgid "Cannot modify undeclared contract status !"
-msgstr "Impossible de modifier le statut du contrat non affecté !"
-
-#. module: tanatech_hr_contract
-#: model:ir.actions.server,name:tanatech_hr_contract.action_draft_contracts
-msgid "Set to draft"
-msgstr "Mettre en brouillon"
-
-#. module: tanatech_hr_contract
-#: model:ir.actions.server,name:tanatech_hr_contract.action_run_contracts
-msgid "Set to running"
-msgstr "Mettre en cours"
-
-#. module: tanatech_hr_contract
-#: model:ir.actions.server,name:tanatech_hr_contract.action_expire_contracts
-msgid "Set to expired"
-msgstr "Définir comme expiré"
-
-#. module: tanatech_hr_contract
-#: model:ir.actions.server,name:tanatech_hr_contract.action_cancel_contracts
-msgid "Set to cancelled"
-msgstr "Définir comme annulé"
-
-#. module: tanatech_hr_contract
-#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.view_hr_payslip_filter_inherit
-msgid "From declared contract"
-msgstr "D'un contrat affecté"
-
-#. module: tanatech_hr_contract
-#: model_terms:ir.ui.view,arch_db:tanatech_hr_contract.view_hr_payslip_filter_inherit
-msgid "From undeclared contract"
-msgstr "D'un contrat non affecté"
 
 #. module: tanatech_hr_contract
 #: model:ir.model.fields,field_description:tanatech_hr_contract.field_hr_salary_attachment__structure_category

--- a/tanatech_hr_contract/migrations/18.0.1.4/post-migrate.py
+++ b/tanatech_hr_contract/migrations/18.0.1.4/post-migrate.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """ Rename the NA mirror contracts from the legacy "N.D." suffix to "NA".
+
+    Ships with the code change that generates the suffix (hr_contract.py):
+    both must land in the same module version, otherwise any later rename of
+    a declared contract would regenerate the "N.D." suffix on its mirror.
+
+    Plain SQL on hr_contract: covers active AND archived contracts, and is
+    idempotent (once no name contains ' - N.D.' anymore, both updates hit
+    zero rows).
+    """
+    # 1) Doubled suffixes first (one known case: "PE DECLARE - N.D. - N.D.").
+    #    Running the generic REPLACE alone would turn them into "... - NA - NA",
+    #    so the doubled pattern is collapsed to a single " - NA" beforehand.
+    cr.execute("""
+        UPDATE hr_contract
+           SET name = REPLACE(name, ' - N.D. - N.D.', ' - NA')
+         WHERE name LIKE '%% - N.D. - N.D.%%'
+    """)
+    doubled = cr.rowcount
+
+    # 2) Generic rename of the remaining legacy suffixes.
+    cr.execute("""
+        UPDATE hr_contract
+           SET name = REPLACE(name, ' - N.D.', ' - NA')
+         WHERE name LIKE '%% - N.D.%%'
+    """)
+    renamed = cr.rowcount
+
+    _logger.info(
+        "ND->NA contract rename: %s doubled suffix(es) collapsed, "
+        "%s contract name(s) renamed.", doubled, renamed,
+    )
+
+    # Safety net: report any leftover N.D. marker (unexpected variants).
+    cr.execute("SELECT id, name FROM hr_contract WHERE name LIKE '%%N.D.%%'")
+    leftovers = cr.fetchall()
+    if leftovers:
+        _logger.warning(
+            "ND->NA contract rename: %s contract(s) still carry an 'N.D.' "
+            "marker and need a manual check: %s", len(leftovers), leftovers,
+        )

--- a/tanatech_hr_contract/models/hr_contract.py
+++ b/tanatech_hr_contract/models/hr_contract.py
@@ -148,7 +148,7 @@ class HrContract(models.Model):
                 if vals.get('state') == 'open':
                     if not not_declared_contract:
                         new_not_declared_contract = contract.copy({
-                            'name' : f'{contract.name} - N.D.',
+                            'name' : f'{contract.name} - NA',
                             'date_start' : contract.date_start,
                             'contract_category' : 'not_declared',
                             'state' : 'open_not_declared',
@@ -171,7 +171,7 @@ class HrContract(models.Model):
                         self.env.cr.commit()
                     else:
                         new_not_declared_contract = contract.copy({
-                            'name' : f'{contract.name} - N.D.',
+                            'name' : f'{contract.name} - NA',
                             'date_start' : contract.date_start,
                             'contract_category' : 'not_declared',
                             'state' : 'draft',
@@ -187,7 +187,7 @@ class HrContract(models.Model):
                         self.env.cr.commit()
                     else:
                         new_not_declared_contract = contract.copy({
-                            'name' : f'{contract.name} - N.D.',
+                            'name' : f'{contract.name} - NA',
                             'date_start' : contract.date_start,
                             'date_end' : contract.date_end,
                             'contract_category' : 'not_declared',
@@ -204,7 +204,7 @@ class HrContract(models.Model):
                         self.env.cr.commit()
                     else:
                         new_not_declared_contract = contract.copy({
-                            'name' : f'{contract.name} - N.D.',
+                            'name' : f'{contract.name} - NA',
                             'date_start' : contract.date_start,
                             'contract_category' : 'not_declared',
                             'state' : 'cancel',
@@ -281,7 +281,7 @@ class HrContract(models.Model):
             # name
             if 'name' in vals:
                 if not_declared_contract:
-                    name = f"{contract.name} - N.D."
+                    name = f"{contract.name} - NA"
                     self.env.cr.execute("""
                         UPDATE hr_contract
                         SET name = %s

--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",
@@ -20,6 +20,7 @@
     "data": [
         "data/hr_work_entry_data.xml",
         "data/hr_attendance_overtime_type_data.xml",
+        "data/ir_actions_server.xml",
         "report/final_settlement.xml",
 
         # views

--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",
@@ -20,7 +20,6 @@
     "data": [
         "data/hr_work_entry_data.xml",
         "data/hr_attendance_overtime_type_data.xml",
-        "data/ir_actions_server.xml",
         "report/final_settlement.xml",
 
         # views

--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/data/ir_actions_server.xml
+++ b/tanatech_hr_payroll/data/ir_actions_server.xml
@@ -13,6 +13,18 @@
         <field name="code">action = records.action_print_payslip()</field>
     </record>
 
+    <!-- Grouped print of the monthly NA payslips on their dedicated 80mm ticket:
+         same report action as the form ticket button, rendered on the filtered
+         selection so the merged PDF is identical to the individual tickets. -->
+    <record id="action_server_print_nd_tickets" model="ir.actions.server">
+        <field name="name">Imprimer les tickets (NA)</field>
+        <field name="model_id" ref="hr_payroll.model_hr_payslip"/>
+        <field name="binding_model_id" ref="hr_payroll.model_hr_payslip"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_print_nd_tickets()</field>
+    </record>
+
     <!-- Unbind the direct report actions from the list "Print" menu: printing them
          directly bypasses _get_pdf_reports, so grouped prints came out on the
          standard template. The server action above is now the only list entry. -->

--- a/tanatech_hr_payroll/data/ir_actions_server.xml
+++ b/tanatech_hr_payroll/data/ir_actions_server.xml
@@ -5,7 +5,7 @@
          same /print/payslips flow as the form button, so _get_pdf_reports routes
          each slip to its own report (custom payslip, final settlement, ...). -->
     <record id="action_server_print_payslips" model="ir.actions.server">
-        <field name="name">Imprimer les bulletins</field>
+        <field name="name">Imprimer les bulletins (A4)</field>
         <field name="model_id" ref="hr_payroll.model_hr_payslip"/>
         <field name="binding_model_id" ref="hr_payroll.model_hr_payslip"/>
         <field name="binding_view_types">list</field>

--- a/tanatech_hr_payroll/data/ir_actions_server.xml
+++ b/tanatech_hr_payroll/data/ir_actions_server.xml
@@ -13,4 +13,14 @@
         <field name="code">action = records.action_print_payslip()</field>
     </record>
 
+    <!-- Unbind the direct report actions from the list "Print" menu: printing them
+         directly bypasses _get_pdf_reports, so grouped prints came out on the
+         standard template. The server action above is now the only list entry. -->
+    <record id="hr_payroll.action_report_payslip" model="ir.actions.report">
+        <field name="binding_model_id" eval="False"/>
+    </record>
+    <record id="hr_payroll.action_report_light_payslip" model="ir.actions.report">
+        <field name="binding_model_id" eval="False"/>
+    </record>
+
 </odoo>

--- a/tanatech_hr_payroll/data/ir_actions_server.xml
+++ b/tanatech_hr_payroll/data/ir_actions_server.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Single entry point for printing payslips from the list view: triggers the
+         same /print/payslips flow as the form button, so _get_pdf_reports routes
+         each slip to its own report (custom payslip, final settlement, ...). -->
+    <record id="action_server_print_payslips" model="ir.actions.server">
+        <field name="name">Imprimer les bulletins</field>
+        <field name="model_id" ref="hr_payroll.model_hr_payslip"/>
+        <field name="binding_model_id" ref="hr_payroll.model_hr_payslip"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_print_payslip()</field>
+    </record>
+
+</odoo>

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -99,8 +99,8 @@ class HrPayslip(models.Model):
         printable_payslips = self - self._filter_nd_ticket_payslips()
         if not printable_payslips:
             raise UserError(_(
-                "Les bulletins NA s'impriment individuellement via leur ticket "
-                "dédié (bouton Imprimer de la fiche)."
+                "Aucun bulletin A4 dans la sélection. Pour les bulletins NA, "
+                "utilisez « Imprimer les tickets (NA) »."
             ))
         return super(HrPayslip, printable_payslips).action_print_payslip()
 

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -104,6 +104,15 @@ class HrPayslip(models.Model):
             ))
         return super(HrPayslip, printable_payslips).action_print_payslip()
 
+    def action_print_nd_tickets(self):
+        # Grouped counterpart of the form ticket button (action_print_nd_payslip):
+        # same report action, so same 80mm paperformat and template — the template
+        # iterates over docs, one merged PDF comes out natively.
+        nd_ticket_payslips = self._filter_nd_ticket_payslips()
+        if not nd_ticket_payslips:
+            raise UserError(_("Aucun bulletin NA dans la sélection."))
+        return self.env.ref('tanatech_hr_payroll.action_report_nd_payslip').report_action(nd_ticket_payslips)
+
     def _get_pdf_reports(self):
         # Route every "Solde Tout Compte" payslip to the final settlement report,
         # whatever the size of the print batch: this method is the single routing

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -1,5 +1,6 @@
 # -*- coding:utf-8 -*-
 from odoo import api, Command, models, fields, _
+from odoo.exceptions import UserError
 import logging
 
 
@@ -80,6 +81,29 @@ class HrPayslip(models.Model):
 
         return super().compute_sheet()
 
+    def _filter_nd_ticket_payslips(self):
+        """ Monthly NA payslips: undeclared structure category and not routed to
+        the final settlement report. They must only be printed through their
+        dedicated 80mm ticket (action_print_nd_payslip). """
+        return self.filtered(
+            lambda slip: slip.struct_id.type_id.structure_category == 'not_declared'
+            and 'Solde Tout Compte' not in (slip.struct_id.name or '')
+        )
+
+    def action_print_payslip(self):
+        # Guard raised here and not in _get_pdf_reports: that one is also called
+        # by _generate_pdf on payslip confirmation, where a UserError would block
+        # the validation of an ND-only batch. Here the server action / form button
+        # runs in a regular RPC, so the error shows up as a clean dialog instead
+        # of the empty zero-page PDF the /print/payslips controller would return.
+        printable_payslips = self - self._filter_nd_ticket_payslips()
+        if not printable_payslips:
+            raise UserError(_(
+                "Les bulletins NA s'impriment individuellement via leur ticket "
+                "dédié (bouton Imprimer de la fiche)."
+            ))
+        return super(HrPayslip, printable_payslips).action_print_payslip()
+
     def _get_pdf_reports(self):
         # Route every "Solde Tout Compte" payslip to the final settlement report,
         # whatever the size of the print batch: this method is the single routing
@@ -87,25 +111,30 @@ class HrPayslip(models.Model):
         # so the reroute must not be restricted to single-slip prints.
         # The substring criterion matches both STC structures (SD and NA) and is
         # kept in sync with _compute_is_nd_ticket_payslip.
+        # Monthly NA payslips are dropped from the mapping: they must never come
+        # out of a batch print nor get the standard A4 slip attached on
+        # confirmation — their 80mm ticket is the only printable form.
         res = super()._get_pdf_reports()
 
         final_settlement_template = self.env.ref('tanatech_hr_payroll.action_report_final_settlement')
         stc_payslips = self.filtered(
             lambda slip: slip.struct_id and 'Solde Tout Compte' in slip.struct_id.name
         )
-        if not stc_payslips:
+        nd_ticket_payslips = self._filter_nd_ticket_payslips()
+        if not stc_payslips and not nd_ticket_payslips:
             return res
 
         for report in list(res.keys()):
-            if report == final_settlement_template:
-                continue
-            remaining = res[report] - stc_payslips
+            remaining = res[report] - nd_ticket_payslips
+            if report != final_settlement_template:
+                remaining -= stc_payslips
             if remaining:
                 res[report] = remaining
             else:
                 # No slip left on this report: drop the entry so no empty PDF
                 # rendering is triggered downstream.
                 del res[report]
-        res[final_settlement_template] |= stc_payslips
+        if stc_payslips:
+            res[final_settlement_template] |= stc_payslips
 
         return res

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -81,15 +81,31 @@ class HrPayslip(models.Model):
         return super().compute_sheet()
 
     def _get_pdf_reports(self):
+        # Route every "Solde Tout Compte" payslip to the final settlement report,
+        # whatever the size of the print batch: this method is the single routing
+        # point of the /print/payslips flow (form button and list server action),
+        # so the reroute must not be restricted to single-slip prints.
+        # The substring criterion matches both STC structures (SD and NA) and is
+        # kept in sync with _compute_is_nd_ticket_payslip.
         res = super()._get_pdf_reports()
 
-        if len(self) == 1 and self.struct_id and 'Solde Tout Compte' in self.struct_id.name:
-            final_settlement_template = self.env.ref('tanatech_hr_payroll.action_report_final_settlement')
-            for payslip in self:
-                for report in list(res.keys()):
-                    if report != final_settlement_template:
-                        res[report] -= payslip
+        final_settlement_template = self.env.ref('tanatech_hr_payroll.action_report_final_settlement')
+        stc_payslips = self.filtered(
+            lambda slip: slip.struct_id and 'Solde Tout Compte' in slip.struct_id.name
+        )
+        if not stc_payslips:
+            return res
 
-                res[final_settlement_template] |= payslip
+        for report in list(res.keys()):
+            if report == final_settlement_template:
+                continue
+            remaining = res[report] - stc_payslips
+            if remaining:
+                res[report] = remaining
+            else:
+                # No slip left on this report: drop the entry so no empty PDF
+                # rendering is triggered downstream.
+                del res[report]
+        res[final_settlement_template] |= stc_payslips
 
         return res

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -18,7 +18,7 @@ class HrPayslip(models.Model):
                 payslip.is_undeclared_payslip = True
 
     is_nd_ticket_payslip = fields.Boolean(
-        'Prints the N.D. 80mm ticket ?', compute="_compute_is_nd_ticket_payslip", store=False)
+        'Prints the NA 80mm ticket ?', compute="_compute_is_nd_ticket_payslip", store=False)
 
     @api.depends('contract_id', 'struct_id')
     def _compute_is_nd_ticket_payslip(self):

--- a/tanatech_hr_payroll/report/final_settlement.xml
+++ b/tanatech_hr_payroll/report/final_settlement.xml
@@ -11,8 +11,10 @@
     <field name="report_name">tanatech_hr_payroll.report_final_settlement</field>
     <field name="report_file">tanatech_hr_payroll.report_final_settlement</field>
     <field name="print_report_name">'Solde de tout compte - %s' % (object.employee_id.name)</field>
-    <field name="binding_model_id" ref="hr_payroll.model_hr_payslip"/>
-    <field name="binding_type">report</field>
+    <!-- Not bound to the list "Print" menu: STC slips are routed to this report
+         by _get_pdf_reports through the /print/payslips flow. eval="False" also
+         clears the binding on databases where it was previously set. -->
+    <field name="binding_model_id" eval="False"/>
   </record>
 
   <!-- =========================================================

--- a/tanatech_hr_payroll/views/report_payslip_nd_templates.xml
+++ b/tanatech_hr_payroll/views/report_payslip_nd_templates.xml
@@ -3,7 +3,7 @@
 
     <!-- 80mm thermal receipt paper format -->
     <record id="paperformat_nd_payslip_ticket" model="report.paperformat">
-        <field name="name">ND Payslip Ticket (80mm)</field>
+        <field name="name">NA Payslip Ticket (80mm)</field>
         <field name="default" eval="False"/>
         <field name="format">custom</field>
         <field name="page_width">80</field>


### PR DESCRIPTION
Déploiement production groupé de deux chantiers validés sur stage_2.

## Versions
| Module | Prod actuelle | Après merge |
|---|---|---|
| `tanatech_hr_payroll` | 1.1.2 | **1.1.7** |
| `tanatech_hr_contract` | 1.3 | **1.4** |

## Chantier impression (tanatech_hr_payroll → 1.1.6)
- Routage STC vers `report_final_settlement` en impression multi-fiches (suppression du verrou mono-fiche)
- Action serveur « Imprimer les bulletins (A4) » sur la vue liste (flux `/print/payslips`)
- Débind des rapports standards (`action_report_payslip` / `_light`) du menu Imprimer
- Exclusion des bulletins NA mensuels du batch A4 (impression via leur ticket dédié)
- Action serveur « Imprimer les tickets (NA) » : impression groupée des tickets 80mm

## Chantier ND→NA (tanatech_hr_contract → 1.4, tanatech_hr_payroll → 1.1.7)
- Suffixe des contrats miroirs `- N.D.` → `- NA` (5 emplacements de `hr_contract.py`)
- Migration `migrations/18.0.1.4/post-migrate.py` : renommage SQL des contrats existants (actifs + archivés, idempotent, doublons repliés, garde-fou loggé)
- Libellés fr.po assainis (dédoublonnage, terminologie « Non Affecté (NA) » unifiée)
- Libellés admin NA (paperformat, champ ticket)

## Déploiement
- Le post-migrate `18.0.1.4` s'exécute à la montée de version de `tanatech_hr_contract` sur la base de production. Surveiller le log « ND->NA contract rename: ... » et l'absence de warning « leftover 'N.D.' marker ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)
