### PR TITLE
[FIX] tanatech_hr_payroll: recharger ir_actions_server.xml (manifest) — actions impression liste absentes en prod

### DIFF
--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",
@@ -20,6 +20,7 @@
     "data": [
         "data/hr_work_entry_data.xml",
         "data/hr_attendance_overtime_type_data.xml",
+        "data/ir_actions_server.xml",
         "report/final_settlement.xml",
 
         # views


### PR DESCRIPTION
## Problème

Les actions serveur d'impression de la vue liste (« Imprimer les bulletins (A4) », « Imprimer les tickets (NA) ») et le débind des rapports standards ne se chargent pas en production : le fichier `tanatech_hr_payroll/data/ir_actions_server.xml` existe dans l'arbre mais **n'est pas listé** dans la clé `data` du manifest, donc Odoo ne l'installe jamais.

## Cause racine

La ligne `"data/ir_actions_server.xml"` a été perdue lors du cherry-pick du chantier ND→NA vers la branche hotfix de production (PR #23). Le conflit sur le manifest (version 1.1.6 avec la ligne vs 1.1.7 sans) a été résolu par `git checkout --theirs`, qui remplace le **fichier entier** par la version du commit ND→NA — commit branché depuis production, où cette ligne n'a jamais existé. La ligne a donc été supprimée silencieusement (le conflit affiché ne montrait que la ligne de version).

## Correctif

- Réintroduction de `"data/ir_actions_server.xml"` à sa position d'origine dans la clé `data`.
- Bump 1.1.7 → 1.1.8 pour que la mise à jour du module recharge le fichier data et installe les records.

Le fichier data lui-même est inchangé (déjà présent). Aucun autre fichier touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
