### PR TITLE
[tanatech_hr_payroll] CP allocation rules, print server actions codification, A4 report gross fix

### DIFF
--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.8",
+    "version": "1.1.10",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/migrations/18.0.1.1.10/post-migrate.py
+++ b/tanatech_hr_payroll/migrations/18.0.1.1.10/post-migrate.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Rule code bodies (stored verbatim as amount_python_compute / condition_python)
+# ---------------------------------------------------------------------------
+
+# hr.leave domain, inserted literally in the "Paie Régulière" rules.
+_LEAVE_DOM = (
+    "[('employee_id', '=', employee.id), "
+    "('state', '=', 'validate'), "
+    "('holiday_status_id.work_entry_type_id.code', '=', 'LEAVE120'), "
+    "('request_date_from', '<=', payslip.date_to), "
+    "('request_date_to', '>=', payslip.date_from)]"
+)
+
+# ---- 'Paie Régulière NA' : source = worked_days (LEAVE120) ----
+_WD_CONDITION = (
+    "result = bool(worked_days.get('LEAVE120') "
+    "and worked_days.get('LEAVE120').number_of_days)"
+)
+_WD_DED_AMOUNT = (
+    "cp_days = worked_days.get('LEAVE120').number_of_days\n"
+    "result = -(contract.wage / 30.0) * cp_days"
+)
+_WD_ALLOC_AMOUNT = (
+    "cp_days = worked_days.get('LEAVE120').number_of_days\n"
+    "result = (contract.wage / 24.0) * cp_days"
+)
+
+# ---- 'Paie Régulière' : source = hr.leave ----
+_LEAVE_CONDITION = "result = bool(payslip.env['hr.leave'].search_count(%s))" % _LEAVE_DOM
+_LEAVE_PREFIX = "\n".join([
+    "cp_days = 0.0",
+    "for l in payslip.env['hr.leave'].search(%s):" % _LEAVE_DOM,
+    "    if l.request_date_from >= payslip.date_from and l.request_date_to <= payslip.date_to:",
+    "        cp_days += l.number_of_days",
+    "    else:",
+    "        start = max(l.request_date_from, payslip.date_from)",
+    "        stop = min(l.request_date_to, payslip.date_to)",
+    "        span = (l.request_date_to - l.request_date_from).days + 1",
+    "        cp_days += l.number_of_days * ((stop - start).days + 1) / span",
+])
+_LEAVE_DED_AMOUNT = _LEAVE_PREFIX + "\nresult = -(contract.wage / 30.0) * cp_days"
+_LEAVE_ALLOC_AMOUNT = _LEAVE_PREFIX + "\nresult = (contract.wage / 24.0) * cp_days"
+
+
+def _rule_specs():
+    """ Rules to codify, grouped by exact structure name. Same names, sequences,
+    categories and flags on both structures; only the data source differs
+    (worked_days for the NA structure, hr.leave for the declared one). """
+    return {
+        'Paie Régulière NA': [
+            {
+                'code': 'CPDED',
+                'name': "Déduction jours de congés payés",
+                'sequence': 1200,
+                'category_code': 'ABS',
+                'condition_python': _WD_CONDITION,
+                'amount_python_compute': _WD_DED_AMOUNT,
+            },
+            {
+                'code': 'CPALLOC',
+                'name': "Allocation congés payés",
+                'sequence': 1210,
+                'category_code': 'PRIME',
+                'condition_python': _WD_CONDITION,
+                'amount_python_compute': _WD_ALLOC_AMOUNT,
+            },
+        ],
+        'Paie Régulière': [
+            {
+                'code': 'CPDED',
+                'name': "Déduction jours de congés payés",
+                'sequence': 1200,
+                'category_code': 'ABS',
+                'condition_python': _LEAVE_CONDITION,
+                'amount_python_compute': _LEAVE_DED_AMOUNT,
+            },
+            {
+                'code': 'CPALLOC',
+                'name': "Allocation congés payés",
+                'sequence': 1210,
+                'category_code': 'PRIME',
+                'condition_python': _LEAVE_CONDITION,
+                'amount_python_compute': _LEAVE_ALLOC_AMOUNT,
+            },
+        ],
+    }
+
+
+def _get_category(env, code, _cache):
+    """ hr.salary.rule.category by exact code, cached; None (+warning) if the
+    category is missing or ambiguous. """
+    if code in _cache:
+        return _cache[code]
+    categories = env['hr.salary.rule.category'].search([('code', '=', code)])
+    if len(categories) != 1:
+        _logger.warning(
+            "CP rules migration: salary rule category with code %r not found "
+            "(or multiple), rules requiring it are skipped.", code)
+        _cache[code] = None
+    else:
+        _cache[code] = categories
+    return _cache[code]
+
+
+def _create_cp_salary_rules(env):
+    """ VOLET 1 — create the paid-leave deduction/allocation salary rules on the
+    two structures, only where they are missing (idempotent). """
+    Rule = env['hr.salary.rule']
+    Structure = env['hr.payroll.structure']
+    category_cache = {}
+
+    for struct_name, rules in _rule_specs().items():
+        structures = Structure.search([('name', '=', struct_name)])
+        if len(structures) != 1:
+            _logger.warning(
+                "CP rules migration: payroll structure %r not found (or "
+                "multiple), its rules are skipped.", struct_name)
+            continue
+        structure = structures
+
+        for spec in rules:
+            existing = Rule.search_count([
+                ('struct_id', '=', structure.id),
+                ('code', '=', spec['code']),
+            ])
+            if existing:
+                continue
+            category = _get_category(env, spec['category_code'], category_cache)
+            if not category:
+                continue
+            Rule.create({
+                'name': spec['name'],
+                'code': spec['code'],
+                'sequence': spec['sequence'],
+                'category_id': category.id,
+                'struct_id': structure.id,
+                'condition_select': 'python',
+                'condition_python': spec['condition_python'],
+                'amount_select': 'code',
+                'amount_python_compute': spec['amount_python_compute'],
+                'appears_on_payslip': True,
+            })
+            _logger.info(
+                "CP rules migration: created rule %s on structure %r.",
+                spec['code'], struct_name)
+
+
+def _create_print_server_actions(env):
+    """ VOLET 2 — codify the two list-view print server actions where they are
+    missing. Guard by (name, model_id) so production instances that already
+    hold them (created without an external id) are left untouched. """
+    model = env['ir.model'].search([('model', '=', 'hr.payslip')], limit=1)
+    if not model:
+        _logger.warning(
+            "CP rules migration: model hr.payslip not found, print server "
+            "actions are skipped.")
+        return
+
+    actions = [
+        {
+            'name': "Imprimer les bulletins (A4)",
+            'code': "action = records.action_print_payslip()",
+        },
+        {
+            'name': "Imprimer les tickets (NA)",
+            'code': "action = records.action_print_nd_tickets()",
+        },
+    ]
+    ServerAction = env['ir.actions.server']
+    for action in actions:
+        existing = ServerAction.search_count([
+            ('name', '=', action['name']),
+            ('model_id', '=', model.id),
+        ])
+        if existing:
+            continue
+        ServerAction.create({
+            'name': action['name'],
+            'model_id': model.id,
+            'binding_model_id': model.id,
+            'binding_view_types': 'list',
+            'state': 'code',
+            'code': action['code'],
+        })
+        _logger.info(
+            "CP rules migration: created server action %r.", action['name'])
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _create_cp_salary_rules(env)
+    _create_print_server_actions(env)

--- a/tanatech_hr_payroll/migrations/18.0.1.1.10/post-migrate.py
+++ b/tanatech_hr_payroll/migrations/18.0.1.1.10/post-migrate.py
@@ -8,6 +8,14 @@ from odoo import api, SUPERUSER_ID
 _logger = logging.getLogger(__name__)
 
 
+def _normalize(label):
+    import unicodedata, re
+    s = unicodedata.normalize('NFKD', label or '')
+    s = ''.join(c for c in s if not unicodedata.combining(c))
+    s = re.sub(r'[^0-9a-zA-Z]+', ' ', s).strip().lower()
+    return s
+
+
 # ---------------------------------------------------------------------------
 # Rule code bodies (stored verbatim as amount_python_compute / condition_python)
 # ---------------------------------------------------------------------------
@@ -119,14 +127,28 @@ def _create_cp_salary_rules(env):
     Structure = env['hr.payroll.structure']
     category_cache = {}
 
+    # Index of every structure by its normalized name, so the target labels are
+    # matched despite case / accent / separator differences (e.g. the production
+    # 'Paie régulière NA' vs the coded 'Paie Régulière NA'). Several structures
+    # can collapse onto the same normalized key: keep them all and skip that key.
+    structures_by_norm = {}
+    for structure in Structure.with_context(active_test=False).search([]):
+        structures_by_norm.setdefault(_normalize(structure.name), Structure)
+        structures_by_norm[_normalize(structure.name)] |= structure
+
     for struct_name, rules in _rule_specs().items():
-        structures = Structure.search([('name', '=', struct_name)])
-        if len(structures) != 1:
+        structure = structures_by_norm.get(_normalize(struct_name))
+        if not structure:
             _logger.warning(
-                "CP rules migration: payroll structure %r not found (or "
-                "multiple), its rules are skipped.", struct_name)
+                "CP rules migration: payroll structure %r not found, its "
+                "rules are skipped.", struct_name)
             continue
-        structure = structures
+        if len(structure) > 1:
+            _logger.warning(
+                "CP rules migration: %s payroll structures normalize to %r, "
+                "its rules are skipped (manual disambiguation required).",
+                len(structure), struct_name)
+            continue
 
         for spec in rules:
             existing = Rule.search_count([

--- a/tanatech_hr_payroll/migrations/18.0.1.1.10/pre-migrate.py
+++ b/tanatech_hr_payroll/migrations/18.0.1.1.10/pre-migrate.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+# Protège les deux actions serveur d'impression AVANT que le rechargement des
+# données du module (data/ir_actions_server.xml) ne s'exécute pour cette montée
+# de version.
+#
+# Ces actions ont pu être créées à la main en base (impression depuis la vue
+# liste) avant d'être codifiées en XML. Sans external ID protégé, le rechargement
+# du fichier data lors de l'upgrade risque de dupliquer l'action ou d'écraser une
+# personnalisation. Ce script, exécuté en pre-migrate, garantit qu'il existe une
+# entrée ir.model.data (dans notre namespace) marquée noupdate=True pour chacune :
+#   - présente            -> on force noupdate=True ;
+#   - absente mais action  -> on crée l'external ID (noupdate=True) qui pointe
+#     serveur existante       sur l'action déjà en base, pour que le XML la mette
+#                             à jour au lieu d'en créer une seconde.
+# Idempotent : une seconde exécution ne modifie plus rien.
+
+_MODULE = "tanatech_hr_payroll"
+_MODEL = "ir.actions.server"
+_PAYSLIP_MODEL = "hr.payslip"
+
+# external ID (name dans ir.model.data) -> nom exact de l'action serveur en base.
+_ACTIONS = [
+    ("action_server_print_payslips", "Imprimer les bulletins (A4)"),
+    ("action_server_print_nd_tickets", "Imprimer les tickets (NA)"),
+]
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    Imd = env["ir.model.data"]
+
+    for xmlid_name, action_name in _ACTIONS:
+        imd = Imd.search([
+            ("module", "=", _MODULE),
+            ("name", "=", xmlid_name),
+            ("model", "=", _MODEL),
+        ], limit=1)
+
+        if imd:
+            if imd.noupdate:
+                _logger.info(
+                    "IR_ACTIONS_SERVER : '%s.%s' déjà protégée (noupdate=True).",
+                    _MODULE, xmlid_name,
+                )
+            else:
+                imd.noupdate = True
+                _logger.info(
+                    "IR_ACTIONS_SERVER : '%s.%s' protégée (noupdate passé à True).",
+                    _MODULE, xmlid_name,
+                )
+            continue
+
+        # Pas d'external ID : on tente de retrouver l'action serveur par son nom,
+        # restreint au modèle hr.payslip pour éviter tout homonyme.
+        action = env[_MODEL].search([
+            ("name", "=", action_name),
+            ("model_id.model", "=", _PAYSLIP_MODEL),
+        ])
+        if not action:
+            _logger.warning(
+                "IR_ACTIONS_SERVER : ni external ID '%s.%s' ni action serveur "
+                "'%s' (sur %s) trouvés — le fichier data la (re)créera.",
+                _MODULE, xmlid_name, action_name, _PAYSLIP_MODEL,
+            )
+            continue
+        if len(action) > 1:
+            _logger.warning(
+                "IR_ACTIONS_SERVER : %s actions nommées '%s' sur %s — "
+                "external ID '%s.%s' non créé (désambiguïsation manuelle requise).",
+                len(action), action_name, _PAYSLIP_MODEL, _MODULE, xmlid_name,
+            )
+            continue
+
+        Imd.create({
+            "module": _MODULE,
+            "name": xmlid_name,
+            "model": _MODEL,
+            "res_id": action.id,
+            "noupdate": True,
+        })
+        _logger.info(
+            "IR_ACTIONS_SERVER : external ID '%s.%s' créé (noupdate=True) "
+            "vers l'action serveur '%s' (id %s).",
+            _MODULE, xmlid_name, action_name, action.id,
+        )

--- a/tanatech_hr_payroll/views/report_payslip_templates.xml
+++ b/tanatech_hr_payroll/views/report_payslip_templates.xml
@@ -222,7 +222,11 @@
             <t t-set="overtime_70" t-value="sum(worked_days_lines_overtime_70.mapped('amount'))"/>
             <t t-set="overtime_100" t-value="sum(worked_days_lines_overtime_100.mapped('amount'))"/>
             <t t-set="gross_salary" t-value="overtime_30 + overtime_40 + overtime_50 + overtime_70 + overtime_100 + o.contract_id.wage"/> -->
-            <t t-set="gross_salary" t-value="o.contract_id.wage"/>
+            <t t-set="basic_line" t-value="payslip_lines.filtered(lambda payslip_line: payslip_line.code == 'BASIC')[:1]"/>
+            <t t-set="gross_line" t-value="payslip_lines.filtered(lambda payslip_line: payslip_line.code == 'GROSS')[:1]"/>
+            <t t-set="basic_salary" t-value="basic_line.total if basic_line else o.contract_id.wage"/>
+            <t t-set="gross_salary" t-value="gross_line.total if gross_line else o.contract_id.wage"/>
+            <t t-set="intermediate_lines" t-value="payslip_lines.filtered(lambda payslip_line: basic_line.sequence &lt; payslip_line.sequence &lt; gross_line.sequence and payslip_line.total and payslip_line.category_id.code not in ('TOTAL01',)) if basic_line and gross_line else payslip_lines.browse()"/>
 
             <!-- Compute deduction -->
             <t t-set="payslip_lines_irsa" t-value="payslip_lines.filtered(lambda payslip_line: payslip_line.category_id.code in ('IRSA02', ))"/>
@@ -261,14 +265,21 @@
                                 <span>Basic salary</span>
                             </td>
                             <td>
-                                <span t-if="o.contract_id.wage">
-                                    <t t-set="formatted_amount_wage" t-value="'{0:,.2f}'.format(o.contract_id.wage)"/>
-                                    <span t-out="formatted_amount_wage" />
-                                </span>
-                                <!-- <span t-if="o.contract_id.wage" t-field="o.contract_id.wage"/> -->
-                                <span t-else="">0</span>
+                                <t t-set="formatted_amount_wage" t-value="'{0:,.2f}'.format(basic_salary)"/>
+                                <span t-out="formatted_amount_wage" />
                             </td>
                         </tr>
+                        <t t-foreach="intermediate_lines" t-as="intermediate_line">
+                            <tr>
+                                <td style=" width: 70%;">
+                                    <span t-out="intermediate_line.name"/>
+                                </td>
+                                <td>
+                                    <t t-set="formatted_amount_intermediate" t-value="'{0:,.2f}'.format(intermediate_line.total)"/>
+                                    <span t-out="formatted_amount_intermediate"/>
+                                </td>
+                            </tr>
+                        </t>
                         <!-- <tr>
                             <td style=" width: 70%;">
                                 <span>Overtime at 30%</span>


### PR DESCRIPTION
Trois volets, un seul commit, sur `tanatech_hr_payroll` (bump 1.1.8 → 1.1.9).

## Volet 1 — Règles de congés payés (migration idempotente)
`migrations/18.0.1.1.9/post-migrate.py` crée, **si absentes** (garde `search_count` sur `struct_id` + `code`), les règles `hr.salary.rule` sur deux structures cherchées par nom exact (warning + skip si absente/multiple) :
- **Paie Régulière NA** (source `worked_days` / LEAVE120) : `CPDED` (déduction, `-wage/30 × jours`) et `CPALLOC` (allocation, `wage/24 × jours`).
- **Paie Régulière** (source `hr.leave`, avec calcul prorata sur chevauchement de période) : mêmes règles.

## Volet 2 — Actions serveur d'impression (même script)
Crée si absentes (garde `name` + `model_id`) les deux `ir.actions.server` sur `hr.payslip`, bindées vue liste : « Imprimer les bulletins (A4) » et « Imprimer les tickets (NA) ». Ces actions existent en prod sans external id — la garde par nom évite tout doublon.

## Volet 3 — Correction du rapport A4
Dans `report_payslip_inherit` : `basic_salary` / `gross_salary` lus depuis les lignes `BASIC` / `GROSS` (fallback `contract.wage`), et affichage des lignes intermédiaires (`intermediate_lines`) entre Salaire de base et Salaire Brut. Blocs déductions / imposable / complementary_lines / montant en lettres inchangés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
