### PR TITLE
[FIX] tanatech_hr_payroll: hr.attendance sans company_id en Odoo 18 (jours fériés)

### DIFF
--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/models/hr_attendance.py
+++ b/tanatech_hr_payroll/models/hr_attendance.py
@@ -102,7 +102,7 @@ class HrAttendanceInherit(models.Model):
             # ('calendar_id', '=', overtime.employee_id.company_id.resource_calendar_id.id),  #Considering employee's calendar or company
             ('resource_id', '=', False)  # resource_id = False => Public holidays
         ])
-        user_tz = timezone(self.env.user.tz or self._context.get('tz') or self.company_id.resource_calendar_id.tz or 'UTC')
+        user_tz = timezone(self.env.user.tz or self._context.get('tz') or self.env.company.resource_calendar_id.tz or 'UTC')
         if public_holidays:
             for holiday in public_holidays:
                 date_from = utc.localize(holiday.date_from).astimezone(user_tz)


### PR DESCRIPTION
## Contexte

`AttributeError: 'hr.attendance' object has no attribute 'company_id'` levé lors de la modification d'un jour férié (`resource.calendar.leaves`) **quand l'utilisateur courant n'a pas de fuseau horaire renseigné**.

Chaîne d'appel :
`resource.calendar.leaves.write` → `_update_overtime` → `_get_overtime_out_of_work_day` → `_get_public_holidays`

## Cause

Dans `_get_public_holidays` (`models/hr_attendance.py`), le fallback de fuseau lisait `self.company_id.resource_calendar_id.tz`. Or `hr.attendance` **n'a pas de champ `company_id` en Odoo 18** (il passe par l'employé), et `self` peut être un recordset multi. Le terme n'était atteint que lorsque `self.env.user.tz` et le `tz` du contexte étaient vides — d'où le bug uniquement pour les utilisateurs sans fuseau.

## Correctif

```diff
- user_tz = timezone(self.env.user.tz or self._context.get('tz') or self.company_id.resource_calendar_id.tz or 'UTC')
+ user_tz = timezone(self.env.user.tz or self._context.get('tz') or self.env.company.resource_calendar_id.tz or 'UTC')
```

`self.env.company` est toujours un singleton et indépendant de l'état de `self`. Le `tz` utilisateur reste la source primaire : **comportement inchangé quand un fuseau est renseigné**.

## Audit associé

- `_get_public_holidays` : seul accès fautif = ligne 105 (corrigé).
- `_get_overtime_out_of_work_day` : RAS — tous les accès `company_id` passent par `attendance.employee_id.company_id` dans la boucle `for attendance in attendances` (singleton par itération), valides.
- Aucun autre `self.company_id` sur `hr.attendance` dans le fichier.

## Version

Module bumpé `1.1.8` → `1.1.9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)