### PR TITLE
[MEP] Chantier STC : solde de tout compte SD/NA (contract 1.5 + payroll 1.2.0)

### DIFF
--- a/tanatech_hr_contract/__manifest__.py
+++ b/tanatech_hr_contract/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Contracts",
-    "version": "1.4",
+    "version": "1.5",
     "summary": "Manage your Contracts activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_contract/migrations/18.0.1.5/post-migrate.py
+++ b/tanatech_hr_contract/migrations/18.0.1.5/post-migrate.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """ Resync the stored field hr_payslip.is_from_undeclared_contract with the
+    restored compute (True when the contract or the structure is not_declared).
+
+    The 552f225 regression forced the compute to False, so every payslip
+    (re)computed since then is stored wrong. Pure SQL, idempotent, and it only
+    touches this one column: amounts, lines and states are never read nor
+    written. A second run updates 0 rows.
+    """
+    cr.execute(
+        """
+        UPDATE hr_payslip p
+           SET is_from_undeclared_contract = sub.expected
+          FROM (
+                SELECT p2.id,
+                       (COALESCE(c.contract_category = 'not_declared', FALSE)
+                        OR COALESCE(t.structure_category = 'not_declared', FALSE)
+                       ) AS expected
+                  FROM hr_payslip p2
+             LEFT JOIN hr_contract c ON c.id = p2.contract_id
+             LEFT JOIN hr_payroll_structure s ON s.id = p2.struct_id
+             LEFT JOIN hr_payroll_structure_type t ON t.id = s.type_id
+               ) sub
+         WHERE sub.id = p.id
+           AND p.is_from_undeclared_contract IS DISTINCT FROM sub.expected
+        """
+    )
+    _logger.info(
+        "is_from_undeclared_contract recomputé sur %s fiche(s) de paie",
+        cr.rowcount,
+    )

--- a/tanatech_hr_contract/models/hr_payroll_structure.py
+++ b/tanatech_hr_contract/models/hr_payroll_structure.py
@@ -8,6 +8,20 @@ class HrPayrollStructure(models.Model):
 
     is_declared_type = fields.Boolean('Is declared type ?', compute='_compute_type', store=True)
 
+    na_structure_id = fields.Many2one(
+        'hr.payroll.structure',
+        string="Structure NA associée",
+        help="Structure non déclarée (NA) jumelle de cette structure déclarée. "
+             "Utilisée pour créer la fiche de paie NA miroir sur la bonne "
+             "structure, sans deviner par nom ou par catégorie.",
+    )
+    is_stc = fields.Boolean(
+        string="Solde de tout compte",
+        help="Identifie les structures de solde de tout compte (déclarée et NA). "
+             "Pilote le routage d'impression (rapport de solde de tout compte "
+             "au lieu du bulletin standard ou du ticket NA 80mm).",
+    )
+
     @api.depends('type_id', 'type_id.structure_category')
     def _compute_type(self):
         for structure in self:

--- a/tanatech_hr_contract/models/hr_payslip.py
+++ b/tanatech_hr_contract/models/hr_payslip.py
@@ -1,7 +1,10 @@
 # -*- coding:utf-8 -*-
+import logging
 from collections import defaultdict
 
 from odoo import api, Command, models, fields
+
+_logger = logging.getLogger(__name__)
 
 
 class HrPayslip(models.Model):
@@ -141,50 +144,68 @@ class HrPayslip(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        """ 
-        Override the create method to create a non-declared payslip once a declared one is created.
-        """
+        """ Override the create method to create the NA (non-declared) mirror
+        payslip once a declared one is created individually (outside a batch).
+
+        The ``skip_na_mirror`` context flag short-circuits the whole override:
+        it is set on the creation of the mirror itself to cut the recursion,
+        and can be used by any caller that must create a payslip without
+        triggering the mirror. """
+        if self.env.context.get('skip_na_mirror'):
+            return super().create(vals_list)
         res = super().create(vals_list)
         for payslip in res:
             if payslip.contract_id.contract_category == 'declared' and not payslip.payslip_run_id:
-                # contract = vals.get('contract_id')
-                # employee = vals.get('employee_id')
-                non_declared_contract = self.env['hr.contract'].search([
-                    ('company_id', '=', payslip.company_id.id),
-                    ('employee_id', '=', payslip.employee_id.id),
-                    ('contract_category', '=', 'not_declared'),
-                    ('state', 'in', ['open_not_declared', 'close']),
-                ], order='create_date desc')
-                non_declared_structure = self.env['hr.payroll.structure'].search([
-                    ('is_declared_type', '=', False)
-                ])
-                name = ' '
-                non_declared_contract_id = non_declared_contract[0]
-                non_declared_structure_id = non_declared_structure[0]
-                date_from = payslip.date_from
-                date_to = payslip.date_to
-                state = payslip.state
-                company_id = payslip.company_id.id
-                
-                self.env.cr.execute("""
-                        INSERT INTO hr_payslip (name, employee_id, contract_id, struct_id, date_from, date_to, company_id, state)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                        RETURNING id
-                    """,
-                    [
-                        name,
-                        payslip.employee_id.id, 
-                        non_declared_contract_id.id, 
-                        non_declared_structure_id.id, 
-                        date_from, 
-                        date_to, 
-                        company_id, 
-                        state
-                    ]
-                )
-                # self.env.cr.execute(query)
-                # self.env.cr.commit()
-                not_declared_payslip_id = self.env.cr.fetchone()
-                created_not_declared_payslip_id = self.env['hr.payslip'].search([('id', '=', not_declared_payslip_id)], limit=1)
-                created_not_declared_payslip_id._compute_worked_days_line_ids()
+                payslip._create_na_mirror_payslip()
         return res
+
+    def _create_na_mirror_payslip(self):
+        """ Create the NA mirror payslip of this declared payslip through the
+        ORM (the historical raw SQL INSERT skipped the name sequence, the
+        stored computes and compute_sheet(), leaving an empty NA slip).
+
+        - the NA structure comes from the explicit mapping
+          ``struct_id.na_structure_id`` (never "the first not_declared one");
+        - the contract is the employee's not_declared mirror contract;
+        - if either is missing: clear log and clean abort, no ghost slip. """
+        self.ensure_one()
+        na_structure = self.struct_id.na_structure_id
+        if not na_structure:
+            _logger.warning(
+                "Fiche NA non créée pour le bulletin %s (id %s) : aucune "
+                "structure NA associée (na_structure_id) sur la structure %r.",
+                self.name, self.id, self.struct_id.name,
+            )
+            return self.env['hr.payslip']
+        na_contract = self.env['hr.contract'].search([
+            ('company_id', '=', self.company_id.id),
+            ('employee_id', '=', self.employee_id.id),
+            ('contract_category', '=', 'not_declared'),
+            ('state', 'in', ['open_not_declared', 'close']),
+        ], order='create_date desc', limit=1)
+        if not na_contract:
+            _logger.warning(
+                "Fiche NA non créée pour le bulletin %s (id %s) : aucun "
+                "contrat miroir not_declared pour l'employé %r.",
+                self.name, self.id, self.employee_id.name,
+            )
+            return self.env['hr.payslip']
+        # 1. Create in draft (no state in the vals): the ORM computes the
+        #    name and the worked days lines, like the batch wizard flow.
+        na_payslip = self.env['hr.payslip'].with_context(skip_na_mirror=True).create({
+            'employee_id': self.employee_id.id,
+            'contract_id': na_contract.id,
+            'struct_id': na_structure.id,
+            'date_from': self.date_from,
+            'date_to': self.date_to,
+            'company_id': self.company_id.id,
+        })
+        # 2. Explicit compute_sheet() while still in draft: salary lines and
+        #    NA amount are generated.
+        na_payslip.compute_sheet()
+        # 3. Align the state on the declared payslip afterwards (the raw SQL
+        #    used to copy it at insert time; compute_sheet only runs on
+        #    draft/verify slips, hence the alignment comes last).
+        if na_payslip.state != self.state:
+            na_payslip.state = self.state
+        return na_payslip

--- a/tanatech_hr_contract/models/hr_payslip.py
+++ b/tanatech_hr_contract/models/hr_payslip.py
@@ -3,6 +3,7 @@ import logging
 from collections import defaultdict
 
 from odoo import api, Command, models, fields
+from odoo.tools import format_date
 
 _logger = logging.getLogger(__name__)
 
@@ -196,9 +197,27 @@ class HrPayslip(models.Model):
                 self.name, self.id, self.employee_id.name,
             )
             return self.env['hr.payslip']
+        # hr_payslip.name is required but its stored compute is not
+        # precomputed at create time on this codebase (the historical reason
+        # for the raw INSERT's name=' '): creating without an explicit name
+        # raises a "required field" ValidationError before the compute runs.
+        # Build it here with the same format as hr_payroll's _compute_name:
+        # "<payslip_name|Salary Slip> - <employee> - <month year>", in the
+        # employee's language.
+        lang = self.employee_id.lang or self.env.user.lang
+        payslip_name = (
+            na_structure.with_context(lang=lang).payslip_name
+            or self.with_context(lang=lang).env._('Salary Slip')
+        )
+        na_name = '%s - %s - %s' % (
+            payslip_name,
+            self.employee_id.name or '',
+            format_date(self.env, self.date_from, date_format="MMMM y", lang_code=lang),
+        )
         # 1. Create in draft (no state in the vals): the ORM computes the
-        #    name and the worked days lines, like the batch wizard flow.
+        #    worked days lines, like the batch wizard flow.
         na_payslip = self.env['hr.payslip'].with_context(skip_na_mirror=True).create({
+            'name': na_name,
             'employee_id': self.employee_id.id,
             'contract_id': na_contract.id,
             'struct_id': na_structure.id,

--- a/tanatech_hr_contract/models/hr_payslip.py
+++ b/tanatech_hr_contract/models/hr_payslip.py
@@ -24,10 +24,16 @@ class HrPayslip(models.Model):
         for payslip in self:
             payslip.net_to_pay_wage = line_values['SALNETAP'][payslip._origin.id]['total']
 
-    @api.depends('contract_id')
+    @api.depends('contract_id.contract_category', 'struct_id.type_id.structure_category')
     def _compute_contract_category(self):
+        # NA (undeclared) payslip: undeclared mirror contract or undeclared
+        # structure. The 552f225 regression forced False everywhere, which made
+        # the declared/undeclared payroll analysis reports mix both worlds.
         for payslip in self:
-            payslip.is_from_undeclared_contract = False
+            payslip.is_from_undeclared_contract = (
+                payslip.contract_id.contract_category == 'not_declared'
+                or payslip.struct_id.type_id.structure_category == 'not_declared'
+            )
 
     def _get_nd_capacity_wage(self):
         """ Wage of the employee's "Undeclared" (NA) contract overlapping this

--- a/tanatech_hr_contract/views/hr_payroll_structure_views.xml
+++ b/tanatech_hr_contract/views/hr_payroll_structure_views.xml
@@ -9,6 +9,8 @@
 
             <xpath expr="//field[@name='type_id']" position="after">
                 <field name="is_declared_type" />
+                <field name="na_structure_id"/>
+                <field name="is_stc"/>
             </xpath>
 
         </field>

--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.1.8",
+    "version": "1.2.0",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -20,16 +20,16 @@ class HrPayslip(models.Model):
     is_nd_ticket_payslip = fields.Boolean(
         'Prints the NA 80mm ticket ?', compute="_compute_is_nd_ticket_payslip", store=False)
 
-    @api.depends('contract_id', 'struct_id')
+    @api.depends('contract_id', 'struct_id', 'struct_id.is_stc')
     def _compute_is_nd_ticket_payslip(self):
         # Only undeclared payslips whose structure is NOT routed to report_final_settlement
-        # (i.e. struct name does not contain 'Solde Tout Compte') keep the dedicated 80mm
-        # "PAIEMENT" ticket (report_nd_payslip). This mirrors the exact substring used by
-        # _get_pdf_reports, so the "Solde Tout Compte - NA" structure (which DOES contain it)
-        # is excluded and follows the standard flow like declared payslips.
+        # (i.e. struct_id.is_stc is False) keep the dedicated 80mm "PAIEMENT" ticket
+        # (report_nd_payslip). This mirrors the exact criterion used by _get_pdf_reports,
+        # so the STC NA structure (flagged is_stc) is excluded and follows the standard
+        # flow like declared payslips.
         for payslip in self:
             undeclared = bool(payslip.contract_id and payslip.contract_id.contract_category == 'not_declared')
-            payslip.is_nd_ticket_payslip = undeclared and 'Solde Tout Compte' not in (payslip.struct_id.name or '')
+            payslip.is_nd_ticket_payslip = undeclared and not payslip.struct_id.is_stc
 
     overtime_hours_count = fields.Float(compute='_compute_overtime_hours')
 
@@ -87,7 +87,7 @@ class HrPayslip(models.Model):
         dedicated 80mm ticket (action_print_nd_payslip). """
         return self.filtered(
             lambda slip: slip.struct_id.type_id.structure_category == 'not_declared'
-            and 'Solde Tout Compte' not in (slip.struct_id.name or '')
+            and not slip.struct_id.is_stc
         )
 
     def action_print_payslip(self):
@@ -114,21 +114,19 @@ class HrPayslip(models.Model):
         return self.env.ref('tanatech_hr_payroll.action_report_nd_payslip').report_action(nd_ticket_payslips)
 
     def _get_pdf_reports(self):
-        # Route every "Solde Tout Compte" payslip to the final settlement report,
-        # whatever the size of the print batch: this method is the single routing
-        # point of the /print/payslips flow (form button and list server action),
-        # so the reroute must not be restricted to single-slip prints.
-        # The substring criterion matches both STC structures (SD and NA) and is
-        # kept in sync with _compute_is_nd_ticket_payslip.
+        # Route every STC payslip (struct_id.is_stc) to the final settlement
+        # report, whatever the size of the print batch: this method is the single
+        # routing point of the /print/payslips flow (form button and list server
+        # action), so the reroute must not be restricted to single-slip prints.
+        # The is_stc flag matches both STC structures (SD and NA) and is kept in
+        # sync with _compute_is_nd_ticket_payslip.
         # Monthly NA payslips are dropped from the mapping: they must never come
         # out of a batch print nor get the standard A4 slip attached on
         # confirmation — their 80mm ticket is the only printable form.
         res = super()._get_pdf_reports()
 
         final_settlement_template = self.env.ref('tanatech_hr_payroll.action_report_final_settlement')
-        stc_payslips = self.filtered(
-            lambda slip: slip.struct_id and 'Solde Tout Compte' in slip.struct_id.name
-        )
+        stc_payslips = self.filtered(lambda slip: slip.struct_id.is_stc)
         nd_ticket_payslips = self._filter_nd_ticket_payslips()
         if not stc_payslips and not nd_ticket_payslips:
             return res


### PR DESCRIPTION
Réécriture ORM de la création des jumelles NA (remplace l'INSERT SQL brut qui produisait une coquille vide sans compute), champs `is_stc` et `na_structure_id` sur `hr.payroll.structure`, routage d'impression migré du libellé de structure vers le flag `is_stc`, restauration de `is_from_undeclared_contract` avec recompute idempotent en post-migrate.

**Recette stage_2** : 6/6 tests validés le 24/07.

**Prérequis production** : tous satisfaits — SALARR (1.1.9), CP (1.1.10), règle BASIC de la structure 'Solde Tout Compte - NA' corrigée en base (suppression de la somme sur `contract_ids`).

**⚠️ ATTENTION exploitation** : après le build, la configuration des structures (`is_stc` et `na_structure_id`) doit être appliquée immédiatement. Tant qu'elle ne l'est pas, `is_stc` vaut False partout et les bulletins STC-NA seraient routés vers le ticket 80mm au lieu du rapport A4. Aucune impression de bulletin pendant cet intervalle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)