### PR TITLE
[FIX] Duplication des entrées de travail au recalcul de bulletin (payroll 1.2.1)

### DIFF
--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/models/hr_payslip.py
+++ b/tanatech_hr_payroll/models/hr_payslip.py
@@ -1,4 +1,6 @@
 # -*- coding:utf-8 -*-
+from datetime import datetime, time
+
 from odoo import api, Command, models, fields, _
 from odoo.exceptions import UserError
 import logging
@@ -72,7 +74,41 @@ class HrPayslip(models.Model):
             payslip.overtime_hours_count = mapped_validated_overtimes.get(payslip.employee_id, 0)
 
     def compute_sheet(self):
+        # generate_work_entries(force=True) court-circuite le garde-fou
+        # date_generated_from/to et NE supprime PAS l'existant : sans nettoyage
+        # préalable, chaque recalcul de bulletin empile un jeu complet d'entrées
+        # de travail identiques (doublons). On reproduit donc le pattern
+        # d'archivage de hr_attendance._regenerate_work_entries : archiver avant
+        # de régénérer.
+        #
+        # Déduplication des couples (employee_id, date_from, date_to) : lors d'un
+        # calcul par lot, la fiche SD et sa jumelle NA portent le même employé et
+        # la même période ; sans cela elles déclencheraient deux fois le même
+        # archivage + régénération (redondant, quoique idempotent).
+        seen = set()
         for slip in self:
+            key = (slip.employee_id.id, slip.date_from, slip.date_to)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            # Même source de vérité que hr_employee.generate_work_entries pour la
+            # liste d'états : on archive exactement l'ensemble qui va être
+            # régénéré (ni les entrées SD légitimes en 'open', ni les entrées
+            # hors période, ni les entrées déjà validées).
+            contracts = slip.employee_id._get_contracts(
+                slip.date_from,
+                slip.date_to,
+                states=["open_not_declared", "close"],
+            )
+            work_entries = self.env['hr.work.entry'].search([
+                ('contract_id', 'in', contracts.ids),
+                ('date_stop', '>=', datetime.combine(slip.date_from, time.min)),
+                ('date_start', '<=', datetime.combine(slip.date_to, time.max)),
+                ('state', '!=', 'validated'),
+            ])
+            work_entries.write({'active': False})
+
             slip.employee_id.generate_work_entries(
                 slip.date_from,
                 slip.date_to,


### PR DESCRIPTION
## Problème

`compute_sheet` (tanatech_hr_payroll) appelait `generate_work_entries(force=True)` sans archiver l'existant au préalable. `force=True` court-circuite le garde-fou `date_generated_from`/`date_generated_to` et ne supprime rien : chaque recalcul de bulletin empilait un jeu complet d'entrées de travail identiques.

**Mesuré en production :** 3608 entrées en trop sur juin-juillet, exclusivement sur contrats `open_not_declared` (3001) et `close` (607) — soit exactement les états ciblés par `hr_employee.generate_work_entries`.

## Correctif

Reproduit le pattern déjà utilisé par `hr_attendance._regenerate_work_entries` (même module) : **archiver avant de régénérer**.

Pour chaque bulletin, avant l'appel `generate_work_entries(force=True)` conservé :
- sélection des contrats via `_get_contracts(states=["open_not_declared", "close"])` — même source de vérité que `hr_employee.generate_work_entries`, pour archiver exactement l'ensemble qui sera régénéré ;
- recherche des `hr.work.entry` rattachées à ces contrats, sur la période `[date_from, date_to]`, `state != 'validated'` ;
- passage à `active = False`.

Déduplication des couples `(employee_id, date_from, date_to)` en tête de méthode : en calcul par lot, la fiche SD et sa jumelle NA partagent employé et période et déclencheraient deux fois le même archivage + régénération.

## Périmètre

- `compute_sheet` conserve la génération `force=True` : les contrats NA (`open_not_declared`) sont exclus du cron standard (`states=['open','close']`), ils n'auraient plus aucune source d'entrées sinon.
- **Non touchés :** cron, wizard, `hr_attendance`.
- Bump manifest `tanatech_hr_payroll` → 1.2.1.
- **Aucune migration** dans cette branche : le nettoyage des 3608 entrées existantes se fera par script shell séparé, après déploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)