### PR TITLE
[FIX] Entrées de travail SD archivées sans régénération à l'édition d'une présence (payroll 1.2.2)

### DIFF
--- a/tanatech_hr_payroll/__manifest__.py
+++ b/tanatech_hr_payroll/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Tanatech Payroll",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "summary": "Manage your Payroll activities",
     "description": "",
     "website": "https://www.nexources.com/",

--- a/tanatech_hr_payroll/models/hr_attendance.py
+++ b/tanatech_hr_payroll/models/hr_attendance.py
@@ -39,8 +39,22 @@ class HrAttendanceInherit(models.Model):
         # Last time of the day (23:59:59)
         last_time = datetime.combine(date_start_tz.date(), time.max)
         last_time_utc = pytz.utc.localize(last_time).astimezone(pytz.utc)
+        # Restreindre l'archivage aux seuls contrats qui seront effectivement
+        # régénérés par generate_work_entries (via la surcharge hr_employee :
+        # open_not_declared, close). Sans ce filtre, les entrées des contrats SD
+        # ('open') sont archivées mais jamais reconstruites (generate ne les
+        # cible pas et date_generated_from/to reste inchangé, donc le cron ne les
+        # rejoue pas) -> bulletins SD sans jours travaillés.
+        # _get_contracts attend des dates : on passe .date(), exactement comme le
+        # fait generate_work_entries en interne (fields.Date.to_date sur ces
+        # mêmes bornes datetime), pour archiver le même ensemble que celui régénéré.
+        contracts = attendance.employee_id._get_contracts(
+            first_time_utc.date(),
+            last_time_utc.date(),
+            states=["open_not_declared", "close"],
+        )
         work_entries = self.env['hr.work.entry'].search([
-            ('employee_id', '=', attendance.employee_id.id),
+            ('contract_id', 'in', contracts.ids),
             ('date_stop', '>=', first_time_utc),
             ('date_start', '<=', last_time_utc),
             ('state', '!=', 'validated')])


### PR DESCRIPTION
## Problème

`_regenerate_work_entries` (tanatech_hr_payroll/models/hr_attendance.py), déclenchée à l'édition d'une présence (`write` sur `employee_id`/`check_in`/`check_out`), archivait les `hr.work.entry` par `employee_id` sur la journée — donc les entrées des contrats **SD (`open`)** ET **NA (`open_not_declared`)**. Elle appelait ensuite `employee.generate_work_entries()` qui, via la surcharge `hr_employee.generate_work_entries`, ne régénère que les contrats **`open_not_declared`** et **`close`**.

Résultat : les entrées SD étaient archivées **définitivement**. `date_generated_from`/`date_generated_to` n'étant pas modifié, le cron standard ne les reconstruisait jamais.

**Mesuré en production :** 252 bulletins de juin sur 566 sans lignes de jours travaillés, dont **239 sur contrats `open`**.

## Correctif

Restreindre le périmètre d'archivage aux **seuls contrats qui seront effectivement régénérés**, exactement comme le correctif 1.2.1 sur `compute_sheet` :

- résolution des contrats via `attendance.employee_id._get_contracts(date_debut, date_fin, states=["open_not_declared", "close"])` — même source de vérité d'états que `hr_employee.generate_work_entries` ;
- recherche des entrées filtrée sur `('contract_id', 'in', contracts.ids)` au lieu de `('employee_id', '=', ...)`.

Typage : `_get_contracts` attend des **dates**. On passe `first_time_utc.date()` / `last_time_utc.date()`, ce qui reproduit la conversion `fields.Date.to_date` que `generate_work_entries` applique en interne à ces mêmes bornes → l'ensemble archivé est rigoureusement celui régénéré.

Conservé à l'identique : calcul de `first_time_utc`/`last_time_utc`, filtre `state != 'validated'`, mécanisme `_work_entry_fields_to_nullify`, appel `generate_work_entries(..., True)`.

## Périmètre

- **Non touchés :** cron, wizard, `compute_sheet`.
- Bump manifest `tanatech_hr_payroll` → 1.2.2.
- **Aucune migration** dans cette branche : la reconstruction des entrées SD manquantes se fera séparément après déploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)